### PR TITLE
in null 并不是真正的 *没问题*

### DIFF
--- a/tiemao_2015/10_Understanding_SQL_Null/10_Understanding_SQL_Null.md
+++ b/tiemao_2015/10_Understanding_SQL_Null/10_Understanding_SQL_Null.md
@@ -89,6 +89,8 @@
 
 如果条件调换过来, 查询结果就没有问题。 现在我们查询有package的用户.
 
+> 译者注：这里的 *没问题* 只是指可以得到查询结果，但并不符合预期，并不会包含 id 为 null 的行
+
 	select * from users 
 	where id in (select user_id from packages)
 


### PR DESCRIPTION
in null 并不是真正的 *没问题*，这里添加备注以免误导读者
仅凭 

> 非真(non-true)值并不影响子句中其他部分的计算结果,相当于被忽略了。

太含蓄